### PR TITLE
fix body and bodyBytes getter from Abortable in logging interceptor

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: "direct main"
     description:
       name: chopper
-      sha256: "18928a74069cf1c257e657809c1b84b0304d8e32a6fc446dd2bbb28657e0358a"
+      sha256: fb6106cd29553e34c811874efd8e8ee051ad7b9546e0d8c79394d2b6c9621b45
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.4.0"
   chopper_generator:
     dependency: "direct main"
     description:
@@ -320,10 +320,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -376,26 +376,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -552,18 +552,10 @@ packages:
     dependency: transitive
     description:
       name: qs_dart
-      sha256: "041c8ae470775b149ca3f7678adf9fb0752d1ab2c44c76aeb681f57379d30f62"
+      sha256: "23e435223d985630e3880fd667128f520237059ca3af0cc2dc029d5365ce9ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.5+1"
-  recursive_regex:
-    dependency: transitive
-    description:
-      name: recursive_regex
-      sha256: f7252e3d3dfd1665e594d9fe035eca6bc54139b1f2fee38256fa427ea41adc60
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+    version: "1.5.6"
   share_plus:
     dependency: transitive
     description:
@@ -725,10 +717,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   timing:
     dependency: transitive
     description:
@@ -789,10 +781,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/lib/src/interceptors/http_logging_interceptor.dart
+++ b/lib/src/interceptors/http_logging_interceptor.dart
@@ -16,10 +16,11 @@ class ChuckerHttpLoggingInterceptor implements Interceptor {
 
     var bytes = '';
     if (requestBase is http.Request) {
-      final body = requestBase.body;
+      final body = (requestBase as http.Request).body;
       if (body.isNotEmpty) {
         Logger.json(body, isRequest: true);
-        bytes = ' (${requestBase.bodyBytes.length}-byte body)';
+        bytes =
+            ' (${(requestBase as http.Request).bodyBytes.length}-byte body)';
       }
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: chopper
-      sha256: "18928a74069cf1c257e657809c1b84b0304d8e32a6fc446dd2bbb28657e0358a"
+      sha256: fb6106cd29553e34c811874efd8e8ee051ad7b9546e0d8c79394d2b6c9621b45
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.4.0"
   clock:
     dependency: transitive
     description:
@@ -145,10 +145,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   http_mock_adapter:
     dependency: "direct dev"
     description:
@@ -177,26 +177,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   logger:
     dependency: transitive
     description:
@@ -321,18 +321,10 @@ packages:
     dependency: transitive
     description:
       name: qs_dart
-      sha256: "041c8ae470775b149ca3f7678adf9fb0752d1ab2c44c76aeb681f57379d30f62"
+      sha256: "23e435223d985630e3880fd667128f520237059ca3af0cc2dc029d5365ce9ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.5+1"
-  recursive_regex:
-    dependency: transitive
-    description:
-      name: recursive_regex
-      sha256: f7252e3d3dfd1665e594d9fe035eca6bc54139b1f2fee38256fa427ea41adc60
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+    version: "1.5.6"
   share_plus:
     dependency: "direct main"
     description:
@@ -462,10 +454,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -518,10 +510,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   very_good_analysis:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,13 +11,13 @@ environment:
   sdk: ">=2.16.0 <4.0.0"
 
 dependencies:
-  chopper: ^8.0.2
+  chopper: ^8.4.0
   dio: ^5.0.3
   flutter:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  http: ^1.0.0
+  http: ^1.5.0
   share_plus: ^11.0.0
   shared_preferences: ^2.0.13
 


### PR DESCRIPTION
## Description

Make getter name fixes for chucker logging interceptor which causes an exception on newest version of Flutter. 
Small issue log: 
```
Xcode's output:
↳
    Writing result bundle at path:
    	/var/folders/wq/bv90yy5s5fb99_1_541x1gz80000gn/T/flutter_tools.cvghMT/flutter_ios_build_temp_dirPLH3F4/temporary_xcresult_bundle

    ../../../.pub-cache/hosted/pub.dev/chucker_flutter-1.8.5/lib/src/interceptors/http_logging_interceptor.dart:19:32: Error: The getter 'body' isn't defined for the type 'Abortable'.
http_logging_interceptor.dart:19
     - 'Abortable' is from 'package:http/src/abortable.dart' ('../../../.pub-cache/hosted/pub.dev/http-1.5.0/lib/src/abortable.dart').
    Try correcting the name to the name of an existing getter, or defining a getter or field named 'body'.
          final body = requestBase.body;
                                   ^^^^
```
As an example you also can see the issue opened in your repository by @lowfreq2010:
https://github.com/syedmurtaza108/chucker-flutter/issues/134

Summary:
- Updated chopper and http packages to the latest version
- Fix the way to apply body and bodyBytes getters for Abortable request type

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
